### PR TITLE
Fix link to Clojars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Clojars](https://img.shields.io/clojars/v/org.clj-commons/pretty-aviso-bridge.svg)](http://clojars.org/org.clj-commons/pretty)
+[![Clojars](https://img.shields.io/clojars/v/org.clj-commons/pretty-aviso-bridge.svg)](http://clojars.org/org.clj-commons/pretty-aviso-bridge)
 [![CI](https://github.com/clj-commons/pretty/actions/workflows/clojure.yml/badge.svg)](https://github.com/clj-commons/pretty/actions/workflows/clojure.yml)
 [![cljdoc badge](https://cljdoc.org/badge/org.clj-commons/pretty)](https://cljdoc.org/d/org.clj-commons/pretty/)
 


### PR DESCRIPTION
It used to point to pretty, now it points to pretty-aviso-bridge